### PR TITLE
send "@@redux-recycle/INIT" as action.type instead of action

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
+    "chai": "^3.4.1",
     "eslint": "^1.7",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-react": "^3.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export default function recycleState (reducer, actions = [], initialState) {
   return (state, action) => {
     if (actions.indexOf(action.type) >= 0) {
       if (initialState === undefined) {
-        return reducer(undefined, '@@redux-recycle/INIT')
+        return reducer(undefined, { type: '@@redux-recycle/INIT' })
       }
       return initialState
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,29 @@
+let { expect } = require('chai')
+let recycleState = require('../src')
+
+describe('recycleState', () => {
+  let reducer = function (state = 'INITIAL_STATE', action) {
+    if (['KNOWN_ACTION', '@@redux-recycle/INIT'].includes(action.type)) {
+      return {
+        state,
+        type: action.type
+      }
+    }
+    return state
+  }
+
+  it('a recycle action', () => {
+    let recycleableReducer = recycleState(reducer, ['RECYCLE'])
+    expect(recycleableReducer('A', { type: 'RECYCLE' })).to.deep.equal({ state: 'INITIAL_STATE', type: '@@redux-recycle/INIT' })
+  })
+
+  it('custom initial state', () => {
+    let recycleableReducer = recycleState(reducer, ['RECYCLE'], 'CUSTOM_INITIAL_STATE')
+    expect(recycleableReducer('A', { type: 'RECYCLE' })).to.deep.equal('CUSTOM_INITIAL_STATE')
+  })
+
+  it('a non-recycle action', () => {
+    let recycleableReducer = recycleState(reducer, ['RECYCLE'])
+    expect(recycleableReducer('A', { type: 'KNOWN_ACTION' })).to.deep.equal({ state: 'A', type: 'KNOWN_ACTION' })
+  })
+})


### PR DESCRIPTION
I believe the intention of the code was to send "@@redux-recycle/INIT" as a `type` of an action instead of the the action itself.

Also added some tests.