### PR TITLE
Ability to run a different reducer instead of returning the a static initialState

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ combineReducers({
 
 Now, once you click the increment button, the state will be reset to `0`.
 
-if you need more complex initialization logic you can provide a `reducer function` as the last param it willadd be used to get the inital state.
+If you need more complex initialization logic, you can provide a `reducer function` as the last param. It will be called with the state and action to get the initial state.
 
 ```js
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install --save redux-recycle
 import recycleState from 'redux-recycle';
 recycleState(reducer, [ARRAY_OF_ACTIONS])
 recycleState(reducer, [ARRAY_OF_ACTIONS], initialState)
+recycleState(reducer, [ARRAY_OF_ACTIONS], resettingReducer)
 ```
 
 
@@ -29,6 +30,8 @@ actions that will reset the state. Optionally, you can also pass an initial
 state to reset to. (defaults to calling your reducer with
 `@@redux-recycle/INIT` and an `undefined` state, which will have the same effect
 as the initial redux action)
+
+if you provide a `reducer function` as the last param it will be used to get the inital state.
 
 Firstly, import `redux-recycle`:
 
@@ -44,6 +47,11 @@ Then, add `recycleState` to your reducer(s) like this:
 ```js
 combineReducers({
   counter: recycleState(counter, [INCREMENT_COUNTER], 0)
+})
+
+// or
+combineReducers({
+  counter: recycleState(counter, [INCREMENT_COUNTER], (state, action) => 0)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install --save redux-recycle
 import recycleState from 'redux-recycle';
 recycleState(reducer, [ARRAY_OF_ACTIONS])
 recycleState(reducer, [ARRAY_OF_ACTIONS], initialState)
-recycleState(reducer, [ARRAY_OF_ACTIONS], resettingReducer)
+recycleState(reducer, [ARRAY_OF_ACTIONS], (state, action) => initialState)
 ```
 
 
@@ -30,8 +30,6 @@ actions that will reset the state. Optionally, you can also pass an initial
 state to reset to. (defaults to calling your reducer with
 `@@redux-recycle/INIT` and an `undefined` state, which will have the same effect
 as the initial redux action)
-
-if you provide a `reducer function` as the last param it will be used to get the inital state.
 
 Firstly, import `redux-recycle`:
 
@@ -48,15 +46,23 @@ Then, add `recycleState` to your reducer(s) like this:
 combineReducers({
   counter: recycleState(counter, [INCREMENT_COUNTER], 0)
 })
-
-// or
-combineReducers({
-  counter: recycleState(counter, [INCREMENT_COUNTER], (state, action) => 0)
-})
 ```
 
 Now, once you click the increment button, the state will be reset to `0`.
 
+if you need more complex initialization logic you can provide a `reducer function` as the last param it willadd be used to get the inital state.
+
+```js
+
+// here you don't allow resetting counting 10 times
+const resetCounter = (state, action) => {
+	return state > 10 ? state : 0
+}
+
+combineReducers({
+  counter: recycleState(counter, [RESET_COUNTERS], resetCounter)
+})
+```
 
 ## What is this magic? How does it work?
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ if you need more complex initialization logic you can provide a `reducer functio
 
 // here you don't allow resetting counting 10 times
 const resetCounter = (state, action) => {
-	return state > 10 ? state : 0
+  return state > 10 ? state : 0
 }
 
 combineReducers({

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-preset-es2015": "^6.5.0",
     "chai": "^3.5.0",
     "eslint": "~2.2.0",
-    "eslint-config-standard": "^5.1.0",
+    "eslint-config-standard": "~5.1.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.2",
     "expect": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "chai": "^3.5.0",
-    "eslint": "^2.2.0",
+    "eslint": "~2.2.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // redux-recycle higher order reducer
 export default function recycleState (reducer, actions = [], initialState) {
-	const getInitialState = (typeof initialState === 'function') ? initialState : () => initialState
+  const getInitialState = (typeof initialState === 'function') ? initialState : () => initialState
 
   return (state, action) => {
     if (actions.indexOf(action.type) >= 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 // redux-recycle higher order reducer
 export default function recycleState (reducer, actions = [], initialState) {
+	const getInitialState = (typeof initialState === 'function') ? initialState : () => initialState
+
   return (state, action) => {
     if (actions.indexOf(action.type) >= 0) {
-      return reducer(initialState, { type: '@@redux-recycle/INIT' })
+      return reducer(getInitialState(state, action), { type: '@@redux-recycle/INIT' })
     }
     return reducer(state, action)
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -27,7 +27,7 @@ describe('recycleState', () => {
     expect(recycleableReducer('A', { type: 'KNOWN_ACTION' })).to.deep.equal({ state: 'A', type: 'KNOWN_ACTION' })
   })
 
-  it('initial state factory', () => {
+  it('initial state reducer', () => {
   	const resetReducer = (state, action) => {
   		return {oldState: state}
   	}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,4 +26,13 @@ describe('recycleState', () => {
     let recycleableReducer = recycleState(reducer, ['RECYCLE'])
     expect(recycleableReducer('A', { type: 'KNOWN_ACTION' })).to.deep.equal({ state: 'A', type: 'KNOWN_ACTION' })
   })
+
+  it('initial state factory', () => {
+  	const resetReducer = (state, action) => {
+  		return {oldState: state}
+  	}
+
+    let recycleableReducer = recycleState(reducer, ['RECYCLE'], resetReducer)
+    expect(recycleableReducer('A', { type: 'RECYCLE' })).to.deep.equal({ state: {oldState: 'A'}, type: '@@redux-recycle/INIT' })
+  })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -28,9 +28,9 @@ describe('recycleState', () => {
   })
 
   it('initial state reducer', () => {
-  	const resetReducer = (state, action) => {
-  		return {oldState: state}
-  	}
+    const resetReducer = (state, action) => {
+      return {oldState: state}
+    }
 
     let recycleableReducer = recycleState(reducer, ['RECYCLE'], resetReducer)
     expect(recycleableReducer('A', { type: 'RECYCLE' })).to.deep.equal({ state: {oldState: 'A'}, type: '@@redux-recycle/INIT' })


### PR DESCRIPTION
I think it can be a common case for example:

```js
function reducer(state = { a: 'should keep its value', b: 0 }, action) {
  switch(action.type) {
    case 'SET_A':
      return {
        ...state,
        a: 'SET!'
      }
    case 'SET_B':
      return {
        ...state,
        b: state.b+1
      }
    default:
      return state
  }
}

function reset(state, action) {
  return {
    ...state
    b: 0
  }
}
```