### PR TITLE
Fix for usage with react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "description": "higher-order reducer to reset the redux state on certain actions",
   "main": "lib/index.js",
+  "files": [
+    "lib/"
+  ],
   "scripts": {
     "clean": "./node_modules/.bin/rimraf lib",
     "build": "./node_modules/.bin/babel src --out-dir lib",


### PR DESCRIPTION
Only include lib in published package. 

The .babelrc file interferes with the react-native bundler.