### PR TITLE
New Feature/Config Option for Setting Initial State When Certain Actions Fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ state to reset to.
 
 Optionally, you can also pass a config object.
 
-Currently, there is one config option:
+Currently, there are two config options:
 
 - `recycleActionType` (default: `@@redux-recycle/INIT`) - if recycleActionType is provided, the reducer function will be called with `initialState` and the provided action name. If set to `false`, the state will be reset without calling the reducer one more time.
+- `setInitialStateActionTypes` (optional) - an array of actions to set `initialState` to as the result of `reducer`.
 
 
 ## API

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,30 @@
 // redux-recycle higher order reducer
 export default function recycleState (reducer, actions, initialState, config = {}) {
-  const getInitialState = (typeof initialState === 'function') ? initialState : () => initialState
   const recycleActionType = (typeof config.recycleActionType === 'undefined') ? '@@redux-recycle/INIT' : config.recycleActionType
+  let setInitialStateActionTypes = []
+  let resetState
+  let getInitialState
+
+  if (typeof initialState === 'function') {
+    getInitialState = initialState
+  } else {
+    resetState = initialState
+    getInitialState = () => resetState
+  }
+
+  if (typeof config.setInitialStateActionTypes !== 'undefined' && Array.isArray(config.setInitialStateActionTypes)) {
+    setInitialStateActionTypes = config.setInitialStateActionTypes
+  }
 
   return (state, action) => {
     if (actions.indexOf(action.type) === -1) {
-      return reducer(state, action)
+      const newState = reducer(state, action)
+
+      if (setInitialStateActionTypes.indexOf(action.type) >= 0) {
+        resetState = newState
+      }
+
+      return newState
     }
 
     if (recycleActionType) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -63,4 +63,12 @@ describe('recycleState', () => {
     let recycleableReducer = recycleState(reducer, ['RECYCLE'], resetReducer, {recycleActionType: false})
     expect(recycleableReducer('A', { type: 'RECYCLE' })).to.deep.equal({oldState: 'A'})
   })
+
+  it('set new initial state', () => {
+    const getNewStateReducer = (state, action) => action.type === 'LOAD' ? 'B' : reducer(state, action)
+    const recycleableReducer = recycleState(getNewStateReducer, ['RECYCLE'], 'A', {setInitialStateActionTypes: ['LOAD']})
+
+    recycleableReducer('A', { type: 'LOAD' }) // set new initial state
+    expect(recycleableReducer('A', { type: 'RECYCLE' })).to.deep.equal({ state: 'B', type: '@@redux-recycle/INIT' })
+  })
 })


### PR DESCRIPTION
I've added a new config option (`setInitialStateActionTypes`) which takes an array of action types. If one of these action types are dispatched for the wrapped reducer then the `initialState` is set to the output of the wrapped reducer. This allows setting the `initialState` based on a specified point in time to reset to (e.g. when a load action occurs).

If `initialState` is a function then this config option is ignored.